### PR TITLE
Add code to show default image if no image provided

### DIFF
--- a/app/src/components/ArtworkInfo.tsx
+++ b/app/src/components/ArtworkInfo.tsx
@@ -107,9 +107,9 @@ class ArtworkInfo extends React.Component<ArtworkInfoProps, ArtworkInfoState> {
     const fields = this.state.fields;
     const artist = this.state.artist;
 
-    const imgSrc = fields.imageIpfsHash === '' ?
-      'https://file.globalupload.io/HO8sN3I2nJ.png' :
-      'https://ipfs.io/ipfs/' + fields.imageIpfsHash;
+    const imgSrc = fields.imageIpfsHash === ''
+      ? 'https://file.globalupload.io/HO8sN3I2nJ.png'
+      : 'https://ipfs.io/ipfs/' + fields.imageIpfsHash;
 
     if (this.state.retrievedData) {
       return (

--- a/app/src/components/ArtworkInfo.tsx
+++ b/app/src/components/ArtworkInfo.tsx
@@ -106,11 +106,16 @@ class ArtworkInfo extends React.Component<ArtworkInfoProps, ArtworkInfoState> {
   render (): React.ReactNode {
     const fields = this.state.fields;
     const artist = this.state.artist;
+
+    const imgSrc = fields.imageIpfsHash === '' ?
+      'https://file.globalupload.io/HO8sN3I2nJ.png' :
+      'https://ipfs.io/ipfs/' + fields.imageIpfsHash;
+
     if (this.state.retrievedData) {
       return (
         <Card className="shadow">
           <Card.Body>
-            <Card.Img variant="top" src={'https://ipfs.io/ipfs/' + fields.imageIpfsHash} />
+            <Card.Img variant="top" src={imgSrc} />
             <Card.Title><span className="text-muted text-capitalize">#{this.props.id} </span>{fields.title}</Card.Title>
             <Card.Subtitle className="mb-2 text-muted">{artist.name}</Card.Subtitle>
             <Card.Text>


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request from master!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
I was getting annoyed at seeing show an error image when trying to load images that haven't been uploaded. Quick fix to show a default image when one doesn't exist

![defaultExample](https://user-images.githubusercontent.com/21280865/68084028-0191f380-fe28-11e9-9b3f-0ba348ae6f74.png)

### Checklist
* [x] Have you done your changes on a separate branch. Branches MUST have descriptive names that start with either the `fix/` or `feature/` prefixes. Good examples are: `fix/signin-loop` or `feature/pr-templates`.
* [x] Have you got descriptive commit messages that would make sense if prefixed with "This commit will ..."
* [x] Will you squash when you merge this PR?

💔Thank you!
