### PR TITLE
Fix artist id not being set during registering if artist dropdown not…

### DIFF
--- a/app/src/components/Register.tsx
+++ b/app/src/components/Register.tsx
@@ -90,7 +90,7 @@ class Register extends React.Component<Drizzled, RegisterState> {
       .then((artists: Artist[]) => {
         const fields = this.state.fields as Pick<RegisterFormFields, keyof RegisterFormFields>;
         // set the default artistId to the first artist, assuming the list of artists is not empty
-        fields.artistId = '1';
+        fields.artistId = artists[0].id.toString();
         this.setState({
           artists: artists,
           fields: fields,

--- a/app/src/components/Register.tsx
+++ b/app/src/components/Register.tsx
@@ -87,7 +87,15 @@ class Register extends React.Component<Drizzled, RegisterState> {
 
   componentDidMount (): void {
     this.getArtistInfo()
-      .then((artists: Artist[]) => this.setState({ artists: artists }))
+      .then((artists: Artist[]) => {
+        const fields = this.state.fields as Pick<RegisterFormFields, keyof RegisterFormFields>;
+        // set the default artistId to the first artist, assuming the list of artists is not empty
+        fields.artistId = '1';
+        this.setState({
+          artists: artists,
+          fields: fields,
+        });
+      })
       .catch((err: any) => console.log(err));
   };
 


### PR DESCRIPTION
… changed, by setting the default to the first artist

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request from master!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
Fixed a bug where if you didn't change the artist drop down when registering it would pass empty string as the artist id and cause the artwork info to hang on loading as it could get the artist. This was fixed by defaulting the artist id to 1 (the first artist) when the list of artists load.

### Checklist
* [x] Have you done your changes on a separate branch. Branches MUST have descriptive names that start with either the `fix/` or `feature/` prefixes. Good examples are: `fix/signin-loop` or `feature/pr-templates`.
* [x] Have you got descriptive commit messages that would make sense if prefixed with "This commit will ..."
* [x] Will you squash when you merge this PR?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

#### Bugs

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests which cover this bug?
* [ ] Have you successfully ran tests with your changes locally?

💔Thank you!
