### PR TITLE
Modify ArtworkList and ClientArtifacts to use CardColumn so multiple …

### DIFF
--- a/app/src/components/ArtworkList.tsx
+++ b/app/src/components/ArtworkList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import ArtworkItem from './ArtworkItem';
-import ListGroup from 'react-bootstrap/ListGroup';
+import CardColumns from 'react-bootstrap/CardColumns';
 
 interface ArtworkListProps {
   drizzle: any;
@@ -82,7 +82,7 @@ class ArtworkList extends React.Component<ArtworkListProps, ArtworkListState> {
     );
 
     return (
-      <ListGroup>{listItems}</ListGroup>
+      <CardColumns>{listItems}</CardColumns>
     );
   }
 }

--- a/app/src/components/ClientArtifacts.tsx
+++ b/app/src/components/ClientArtifacts.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import ArtworkItem from './ArtworkItem';
-import ListGroup from 'react-bootstrap/ListGroup';
+import CardColumns from 'react-bootstrap/CardColumns';
 
 interface ClientArtifactsProps {
   drizzle: any;
@@ -69,7 +69,7 @@ class ClientArtifacts extends
     );
 
     return (
-      <ListGroup>{listItems}</ListGroup>
+      <CardColumns>{listItems}</CardColumns>
     );
   }
 }


### PR DESCRIPTION
…artifact cards can be displayed side to side

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request from master!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description
Make it so that Artifacts display at a reasonable size in the Artifacts and ClientArtifacts view when in full screen. The Goverance page seems to use CardColumns so I don't see why these shouldn't.
![Screenshot from 2019-11-04 11-45-30](https://user-images.githubusercontent.com/34010372/68119149-dd9ee280-fef9-11e9-91cc-bd567533cb0c.png)


### Checklist
* [x] Have you done your changes on a separate branch. Branches MUST have descriptive names that start with either the `fix/` or `feature/` prefixes. Good examples are: `fix/signin-loop` or `feature/pr-templates`.
* [x] Have you got descriptive commit messages that would make sense if prefixed with "This commit will ..."
* [x] Will you squash when you merge this PR?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

#### New Features

1. [x] Does your submission have a high coverage of your feature?
2. [x] Have you lint your code locally prior to submission?

💔Thank you!
