### PR TITLE
Fix truffle compile error where compiler version used differs from co…

### DIFF
--- a/contracts/ArtifactApplication.sol
+++ b/contracts/ArtifactApplication.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/ArtifactRegistry.sol
+++ b/contracts/ArtifactRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/ownership/Ownable.sol";

--- a/contracts/Artists.sol
+++ b/contracts/Artists.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/drafts/Counters.sol";

--- a/contracts/ENS.sol
+++ b/contracts/ENS.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 
 import "@ensdomains/ens/contracts/ENSRegistry.sol";
 import "@ensdomains/ens/contracts/FIFSRegistrar.sol";

--- a/contracts/ERC721ApprovalEnumerable.sol
+++ b/contracts/ERC721ApprovalEnumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721Full.sol";

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import { Moderated } from "./Moderated.sol";

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 
 contract Migrations {
   address public owner;

--- a/contracts/Moderated.sol
+++ b/contracts/Moderated.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 
 import "@openzeppelin/contracts/ownership/Ownable.sol";
 

--- a/contracts/interfaces/IArtifactRegistry.sol
+++ b/contracts/interfaces/IArtifactRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/interfaces/IERC721ApprovalEnumerable.sol
+++ b/contracts/interfaces/IERC721ApprovalEnumerable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/interfaces/IGovernance.sol
+++ b/contracts/interfaces/IGovernance.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 contract IGovernance {

--- a/contracts/mocks/ArtifactRegistryMock.sol
+++ b/contracts/mocks/ArtifactRegistryMock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 import { ArtifactRegistry } from "../ArtifactRegistry.sol";

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/contracts/mocks/ERC721ReceiverMock.sol
+++ b/contracts/mocks/ERC721ReceiverMock.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 

--- a/contracts/mocks/MockTarget.sol
+++ b/contracts/mocks/MockTarget.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.8;
+pragma solidity 0.5.12;
 pragma experimental ABIEncoderV2;
 
 contract MockTarget {


### PR DESCRIPTION
…mpiler version specified in source files by upgrading version in source files to 0.5.12

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request from master!
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.

### Description
Seemingly within the last 2 hours, I think truffle has updated so that it enforces that the compiler version specified must be the compiler version used to compile contracts. This causes the error `ParserError: Source file requires different compiler version (current compiler is 0.5.12+commit.7709ece9.Emscripten.clang - note that nightly builds are considered to be strictly less than the released version` to occur when compiling our contracts as we specify 0.5.8 in our source files but use the compiler which truffle uses (0.5.12 at the moment).

### Checklist
* [ ] Have you done your changes on a separate branch. Branches MUST have descriptive names that start with either the `fix/` or `feature/` prefixes. Good examples are: `fix/signin-loop` or `feature/pr-templates`.
* [ ] Have you got descriptive commit messages that would make sense if prefixed with "This commit will ..."
* [ ] Will you squash when you merge this PR?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

#### Bugs

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests which cover this bug?
* [ ] Have you successfully ran tests with your changes locally?

💔Thank you!
