### PR TITLE
Replace Updated 3 minutes ago with useful, accurate data

### DIFF
--- a/app/src/components/ArrItem.tsx
+++ b/app/src/components/ArrItem.tsx
@@ -42,10 +42,10 @@ const ArrItem: React.FC<ArrItemProps> = ({ id }) => {
       setArr(arr);
     };
 
-    const getLastUpdated = async () => {
+    const getLastUpdated = async (): Promise<void> => {
       const options = { fromBlock: 0 };
       const events = await ArtifactRegistry.getPastEvents('Propose', options)
-        .then((es: EventData[]) => es.filter(e => e.returnValues.proposalId === id!.toString()));
+        .then((es: EventData[]) => es.filter(e => e.returnValues.proposalId === id.toString()));
       const event = events[events.length - 1];
       const timestamp = await web3.eth.getBlock(event.blockNumber)
         .then((block) => block.timestamp);

--- a/app/src/components/ArrItem.tsx
+++ b/app/src/components/ArrItem.tsx
@@ -4,6 +4,9 @@ import PlaintextField from './common/PlaintextField';
 import AddressField from './common/AddressField';
 import Form from 'react-bootstrap/Form';
 import { useContractContext } from '../providers/ContractProvider';
+import { useWeb3Context } from '../providers/Web3Provider';
+import { EventData } from 'web3-eth-contract';
+import * as moment from 'moment';
 
 interface ArrItemProps {
   id: number;
@@ -20,8 +23,10 @@ interface ArrItemType {
 
 const ArrItem: React.FC<ArrItemProps> = ({ id }) => {
   const [arr, setArr] = React.useState<ArrItemType>();
+  const [lastUpdateTime, setUpdateTime] = React.useState<string>('Checking');
 
-  const { ArtifactApplication } = useContractContext();
+  const { web3 } = useWeb3Context();
+  const { ArtifactApplication, ArtifactRegistry } = useContractContext();
 
   React.useEffect(() => {
     const loadArr = async (): Promise<void> => {
@@ -37,8 +42,21 @@ const ArrItem: React.FC<ArrItemProps> = ({ id }) => {
       setArr(arr);
     };
 
+    const getLastUpdated = async () => {
+      const options = { fromBlock: 0 };
+      const events = await ArtifactRegistry.getPastEvents('Propose', options)
+        .then((es: EventData[]) => es.filter(e => e.returnValues.proposalId === id!.toString()));
+      const event = events[events.length - 1];
+      const timestamp = await web3.eth.getBlock(event.blockNumber)
+        .then((block) => block.timestamp);
+
+      const txDate = moment.unix(Number(timestamp));
+      setUpdateTime('Last Updated ' + txDate.fromNow());
+    };
+
     loadArr();
-  }, [ArtifactApplication, id]);
+    getLastUpdated();
+  }, [ArtifactApplication, id, ArtifactRegistry, web3]);
 
   if (!arr) {
     return null;
@@ -59,7 +77,7 @@ const ArrItem: React.FC<ArrItemProps> = ({ id }) => {
         </Form>
       </Card.Body>
       <Card.Footer>
-        <small className="text-muted">Last updated 3 mins ago</small>
+        <small className="text-muted"> {lastUpdateTime} </small>
       </Card.Footer>
     </Card>
   );

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -58,7 +58,7 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
       setUpdateTime('Last Updated ' + txDate.fromNow());
     };
     getLastUpdated();
-  }, [ArtifactRegistry, id]);
+  }, [ArtifactRegistry, id, web3]);
 
   const path = `artifact/${id}`;
   return (

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -14,7 +14,7 @@ import { useWeb3Context } from '../providers/Web3Provider';
 import * as moment from 'moment';
 
 interface ArtworkCardProps {
-  id?: number;
+  id: number;
   img?: string;
   metaUri?: string;
   fields?: ArtworkInfoFields;
@@ -51,15 +51,15 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
     const getLastUpdated = async () => {
       const options = { fromBlock: 0 };
       const events = await ArtifactRegistry.getPastEvents('Transfer', options)
-        .then((es: EventData[]) => es.filter(e => e.returnValues.tokenId === '1'));
+        .then((es: EventData[]) => es.filter(e => e.returnValues.tokenId === id!.toString()));
       const event = events[events.length-1];
       const timestamp = await web3.eth.getBlock(event.blockNumber)
         .then((block) => block.timestamp);
-        
+
       const txDate = moment.unix(Number(timestamp));
       setUpdateTime('Last Updated ' + txDate.fromNow());
     };
-    getLastUpdated()
+      getLastUpdated();
   }, []);
 
   const path = `artifact/${id}`;

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -46,15 +46,15 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
   const { ArtifactRegistry, Governance } = useContractContext();
 
   React.useEffect(() => {
-    const getLastUpdated = async () => {
+    const getLastUpdated = async (): Promise<void> => {
       const options = { fromBlock: 0 };
       let events = await ArtifactRegistry.getPastEvents('Transfer', options)
         .then((es: EventData[]) =>
-          es.filter(e => e.returnValues.tokenId === id!.toString()));
+          es.filter(e => e.returnValues.tokenId === id.toString()));
       if (events.length === 0) {
         events = await Governance.getPastEvents('Propose', options)
           .then((es: EventData[]) =>
-            es.filter(e => e.returnValues.proposalId === id!.toString()));
+            es.filter(e => e.returnValues.proposalId === id.toString()));
       }
       const event = events[events.length - 1];
       const timestamp = await web3.eth.getBlock(event.blockNumber)

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -40,7 +40,6 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
   fullscreen,
   children,
 }) => {
-
   const { web3 } = useWeb3Context();
   const { ArtifactRegistry } = useContractContext();
 
@@ -49,9 +48,9 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
     .then((es: EventData[]) => es.filter(e => e.returnValues.tokenId === '1'));
   if (events.length > 0) {
     console.log('Found an event in ArtworkCard');
-    const mostRecentEvent = events[events.length-1];
+    const mostRecentEvent = events[events.length - 1];
     const timestamp = web3.eth.getBlock(mostRecentEvent.blockNumber)
-    .then((block) => block.timestamp);
+      .then((block) => block.timestamp);
     const txDate = moment.unix(Number(timestamp));
     console.log(txDate);
   }

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -52,7 +52,6 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
         .then((es: EventData[]) =>
           es.filter(e => e.returnValues.tokenId === id!.toString()));
       if (events.length === 0) {
-        console.log('found no events');
         events = await Governance.getPastEvents('Propose', options)
           .then((es: EventData[]) =>
             es.filter(e => e.returnValues.proposalId === id!.toString()));

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -50,12 +50,12 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
       const options = { fromBlock: 0 };
       let events = await ArtifactRegistry.getPastEvents('Transfer', options)
         .then((es: EventData[]) =>
-        es.filter(e => e.returnValues.tokenId === id!.toString()));
+          es.filter(e => e.returnValues.tokenId === id!.toString()));
       if (events.length === 0) {
         console.log('found no events');
         events = await Governance.getPastEvents('Propose', options)
-        .then((es:EventData[]) =>
-          es.filter(e => e.returnValues.proposalId === id!.toString()));
+          .then((es: EventData[]) =>
+            es.filter(e => e.returnValues.proposalId === id!.toString()));
       }
       const event = events[events.length - 1];
       const timestamp = await web3.eth.getBlock(event.blockNumber)

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -60,7 +60,7 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
       setUpdateTime('Last Updated ' + txDate.fromNow());
     };
       getLastUpdated();
-  }, []);
+  }, [ArtifactRegistry, id]);
 
   const path = `artifact/${id}`;
   return (

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -64,7 +64,7 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
       setUpdateTime('Last Updated ' + txDate.fromNow());
     };
     getLastUpdated();
-  }, [ArtifactRegistry, id, web3]);
+  }, [ArtifactRegistry, id, web3, Governance]);
 
   const path = `artifact/${id}`;
   return (

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -22,6 +22,8 @@ interface ArtworkCardProps {
   fullscreen?: true;
 }
 
+
+
 export const MetadataArtworkCard: React.FC = ({ children }) => {
   return (
     <Card bg="primary" text="white" className="text-center p-3">
@@ -40,20 +42,25 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
   fullscreen,
   children,
 }) => {
+  const [lastUpdateTime, setUpdateTime] = React.useState<String>('Checking');
+
   const { web3 } = useWeb3Context();
   const { ArtifactRegistry } = useContractContext();
 
-  const options = { fromBlock: 0 };
-  const events = ArtifactRegistry.getPastEvents('Transfer', options)
-    .then((es: EventData[]) => es.filter(e => e.returnValues.tokenId === '1'));
-  if (events.length > 0) {
-    console.log('Found an event in ArtworkCard');
-    const mostRecentEvent = events[events.length - 1];
-    const timestamp = web3.eth.getBlock(mostRecentEvent.blockNumber)
-      .then((block) => block.timestamp);
-    const txDate = moment.unix(Number(timestamp));
-    console.log(txDate);
-  }
+  React.useEffect(() => {
+    const getLastUpdated = async () => {
+      const options = { fromBlock: 0 };
+      const events = await ArtifactRegistry.getPastEvents('Transfer', options)
+        .then((es: EventData[]) => es.filter(e => e.returnValues.tokenId === '1'));
+      const event = events[events.length-1];
+      const timestamp = await web3.eth.getBlock(event.blockNumber)
+        .then((block) => block.timestamp);
+        
+      const txDate = moment.unix(Number(timestamp));
+      setUpdateTime('Last Updated ' + txDate.fromNow());
+    };
+    getLastUpdated()
+  }, []);
 
   const path = `artifact/${id}`;
   return (
@@ -112,7 +119,8 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
 
       </Card.Body>
       <Card.Footer>
-        <small className="text-muted">Last updated 3 mins ago</small>
+
+        <small className="text-muted"> {lastUpdateTime} </small>
       </Card.Footer>
     </Card>
   );

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -8,6 +8,10 @@ import { Documents, DocumentsModal } from './Documents';
 import { Link } from 'react-router-dom';
 import Form from 'react-bootstrap/Form';
 import PlaintextField from './common/PlaintextField';
+import { useContractContext } from '../providers/ContractProvider';
+import { EventData } from 'web3-eth-contract';
+import { useWeb3Context } from '../providers/Web3Provider';
+import * as moment from 'moment';
 
 interface ArtworkCardProps {
   id?: number;
@@ -36,6 +40,22 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
   fullscreen,
   children,
 }) => {
+
+  const { web3 } = useWeb3Context();
+  const { ArtifactRegistry } = useContractContext();
+
+  const options = { fromBlock: 0 };
+  const events = ArtifactRegistry.getPastEvents('Transfer', options)
+    .then((es: EventData[]) => es.filter(e => e.returnValues.tokenId === '1'));
+  if (events.length > 0) {
+    console.log('Found an event in ArtworkCard');
+    const mostRecentEvent = events[events.length-1];
+    const timestamp = web3.eth.getBlock(mostRecentEvent.blockNumber)
+    .then((block) => block.timestamp);
+    const txDate = moment.unix(Number(timestamp));
+    console.log(txDate);
+  }
+
   const path = `artifact/${id}`;
   return (
     <Card className="shadow">

--- a/app/src/components/ArtworkCard.tsx
+++ b/app/src/components/ArtworkCard.tsx
@@ -22,8 +22,6 @@ interface ArtworkCardProps {
   fullscreen?: true;
 }
 
-
-
 export const MetadataArtworkCard: React.FC = ({ children }) => {
   return (
     <Card bg="primary" text="white" className="text-center p-3">
@@ -42,7 +40,7 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
   fullscreen,
   children,
 }) => {
-  const [lastUpdateTime, setUpdateTime] = React.useState<String>('Checking');
+  const [lastUpdateTime, setUpdateTime] = React.useState<string>('Checking');
 
   const { web3 } = useWeb3Context();
   const { ArtifactRegistry } = useContractContext();
@@ -52,14 +50,14 @@ const ArtworkCard: React.FC<ArtworkCardProps> = ({
       const options = { fromBlock: 0 };
       const events = await ArtifactRegistry.getPastEvents('Transfer', options)
         .then((es: EventData[]) => es.filter(e => e.returnValues.tokenId === id!.toString()));
-      const event = events[events.length-1];
+      const event = events[events.length - 1];
       const timestamp = await web3.eth.getBlock(event.blockNumber)
         .then((block) => block.timestamp);
 
       const txDate = moment.unix(Number(timestamp));
       setUpdateTime('Last Updated ' + txDate.fromNow());
     };
-      getLastUpdated();
+    getLastUpdated();
   }, [ArtifactRegistry, id]);
 
   const path = `artifact/${id}`;

--- a/app/src/components/ArtworkInfo.tsx
+++ b/app/src/components/ArtworkInfo.tsx
@@ -120,7 +120,7 @@ const ArtworkInfo: React.FC<ArtworkInfoProps> = ({ artwork, id, fullscreen, chil
   }
 
   return (
-    <ArtworkCard img={imgSrc} fullscreen={fullscreen}>
+    <ArtworkCard id={id} img={imgSrc} fullscreen={fullscreen}>
       {children}
     </ArtworkCard>
   );

--- a/app/src/components/ArtworkItem.tsx
+++ b/app/src/components/ArtworkItem.tsx
@@ -30,7 +30,7 @@ const ArtworkItem: React.FC<ArtworkItemProps> = ({ tokenId, ownedArtifact, fulls
   }, [ArtifactRegistry.methods, tokenId]);
 
   if (!artwork) {
-    return <ArtworkCard img='https://file.globalupload.io/HO8sN3I2nJ.png'/>;
+    return <ArtworkCard id={tokenId} img='https://file.globalupload.io/HO8sN3I2nJ.png'/>;
   }
 
   return (


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request from master!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description

Replace updated 3 minutes ago that was displayed at the bottom of all artwork cards with the time elapsed since the last transfer event emitted for that token ID.

Notable exception in the case that no transfer events have ever been emitted, in which case the ArtworkCard is being displayed via the ProposalList. In this case, if we do not find any transfer events, instead look for a Propose event emitted by the governance contract and use this to generate the time elapsed data. 

![Screenshot from 2019-11-28 15-03-34](https://user-images.githubusercontent.com/22823699/69816701-d1ecc600-11f0-11ea-85d6-85b5c8958d29.png)


### Checklist
* [x] Have you done your changes on a separate branch. Branches MUST have descriptive names that start with either the `fix/` or `feature/` prefixes. Good examples are: `fix/signin-loop` or `feature/pr-templates`.
* [x] Have you got descriptive commit messages that would make sense if prefixed with "This commit will ..."
* [x] Will you squash when you merge this PR?