### PR TITLE
Store a wallet for artist upon creation, and fix bug where user created artists did not have an id

### DIFF
--- a/app/src/components/RegisterArtist.tsx
+++ b/app/src/components/RegisterArtist.tsx
@@ -72,7 +72,7 @@ const RegisterArtist: React.FC = () => {
     event.stopPropagation();
     event.preventDefault();
 
-    if(fields.wallet === '') {
+    if (fields.wallet === '') {
       const account = web3.eth.accounts.create();
       account.privateKey = '';
       fields.wallet = account.address;
@@ -92,7 +92,6 @@ const RegisterArtist: React.FC = () => {
     }
 
     setSubmitted(true);
-
 
     // eslint-disable-next-line
     const { metaIpfsHash, ...restOfTheFields } = fields;
@@ -141,8 +140,7 @@ const RegisterArtist: React.FC = () => {
   };
 
   const renderArtistInformation = (): React.ReactNode => {
-
-    const handleClose = () => setInvalidENS(false);
+    const handleClose = (): void => setInvalidENS(false);
 
     return (
       <Container>
@@ -195,7 +193,7 @@ const RegisterArtist: React.FC = () => {
           </Form.Group>
         </Form.Row>
         <Modal
-          { ...{show: invalidENS, title:'Invalid Username entered', animation: false}}
+          { ...{ show: invalidENS, title: 'Invalid Username entered', animation: false }}
           size="lg"
           aria-labelledby="contained-modal-title-vcenter"
           centered

--- a/app/src/components/RegisterArtist.tsx
+++ b/app/src/components/RegisterArtist.tsx
@@ -12,6 +12,7 @@ import { IPFS_URL_START, saveSingleToIPFS } from '../helper/ipfs';
 import { useContractContext } from '../providers/ContractProvider';
 import { useWeb3Context } from '../providers/Web3Provider';
 import { useNameServiceContext } from '../providers/NameServiceProvider';
+import Modal from 'react-bootstrap/Modal';
 
 interface RegisterFormFields {
   name: string;
@@ -44,6 +45,7 @@ const RegisterArtist: React.FC = () => {
   const [validated, setValidated] = React.useState<boolean>(false);
   const [submitted, setSubmitted] = React.useState<boolean>(false);
   const [isGovernor, setIsGovernor] = React.useState<boolean>(false);
+  const [invalidENS, setInvalidENS] = React.useState<boolean>(false);
 
   const { Governance, Artists } = useContractContext();
   const { web3, accounts } = useWeb3Context();
@@ -85,6 +87,7 @@ const RegisterArtist: React.FC = () => {
       }
     }
     if (!validated) {
+      setInvalidENS(true);
       return;
     }
 
@@ -138,6 +141,9 @@ const RegisterArtist: React.FC = () => {
   };
 
   const renderArtistInformation = (): React.ReactNode => {
+
+    const handleClose = () => setInvalidENS(false);
+
     return (
       <Container>
         <Form.Row>
@@ -188,6 +194,24 @@ const RegisterArtist: React.FC = () => {
             {GENERIC_FEEDBACK}
           </Form.Group>
         </Form.Row>
+        <Modal
+          { ...{show: invalidENS, title:'Invalid Username entered', animation: false}}
+          size="lg"
+          aria-labelledby="contained-modal-title-vcenter"
+          centered
+        >
+          <Modal.Header>
+            <Modal.Title id="contained-modal-title-vcenter">
+              {'Invalid Username entered'}
+            </Modal.Title>
+          </Modal.Header>
+          <Modal.Body>Sorry, we couldn&apos;t find an account with that Username</Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={handleClose}>
+              Close
+            </Button>
+          </Modal.Footer>
+        </Modal>
       </Container>
     );
   };

--- a/app/src/components/RegisterArtist.tsx
+++ b/app/src/components/RegisterArtist.tsx
@@ -50,12 +50,6 @@ const RegisterArtist: React.FC = () => {
   const { addressFromName } = useNameServiceContext();
 
   React.useEffect(() => {
-    const account = web3.eth.accounts.create();
-    account.privateKey = '';
-    fields.wallet = account.address;
-  });
-
-  React.useEffect(() => {
     Governance.methods.isGovernor(accounts[0])
       .call()
       .then((isGovernor: any) => {
@@ -76,20 +70,26 @@ const RegisterArtist: React.FC = () => {
     event.stopPropagation();
     event.preventDefault();
 
-    const form = event.currentTarget;
-    if (!form.checkValidity()) {
+    if(fields.wallet === '') {
+      const account = web3.eth.accounts.create();
+      account.privateKey = '';
+      fields.wallet = account.address;
+      setValidated(true);
+    } else {
+      const accountAddress = await addressFromName(fields.wallet);
+      if (accountAddress !== '') {
+        const newFields = fields;
+        newFields.wallet = accountAddress;
+        setFields(newFields);
+        setValidated(true);
+      }
+    }
+    if (!validated) {
       return;
     }
 
-    setValidated(true);
     setSubmitted(true);
 
-    const accountAddress = await addressFromName(fields.wallet);
-    if (accountAddress !== '') {
-      const newFields = fields;
-      newFields.wallet = accountAddress;
-      setFields(newFields);
-    }
 
     // eslint-disable-next-line
     const { metaIpfsHash, ...restOfTheFields } = fields;
@@ -164,7 +164,6 @@ const RegisterArtist: React.FC = () => {
           <Form.Group as={Col} controlId="wallet">
             <Form.Label>Artist&apos;s ARRtistry Username (optional)</Form.Label>
             <Form.Control
-              required
               type="text"
               onChange={inputChangeHandler}/>
             {GENERIC_FEEDBACK}

--- a/app/src/components/RegisterArtist.tsx
+++ b/app/src/components/RegisterArtist.tsx
@@ -72,25 +72,26 @@ const RegisterArtist: React.FC = () => {
     event.stopPropagation();
     event.preventDefault();
 
+    let walletValid = false;
     if (fields.wallet === '') {
       const account = web3.eth.accounts.create();
       account.privateKey = '';
       fields.wallet = account.address;
-      setValidated(true);
+      walletValid = true;
     } else {
       const accountAddress = await addressFromName(fields.wallet);
       if (accountAddress !== '') {
-        const newFields = fields;
-        newFields.wallet = accountAddress;
-        setFields(newFields);
-        setValidated(true);
+        fields.wallet = accountAddress;
+        walletValid = true;
       }
     }
-    if (!validated) {
+
+    if (!walletValid) {
       setInvalidENS(true);
       return;
     }
 
+    setValidated(true);
     setSubmitted(true);
 
     // eslint-disable-next-line

--- a/app/src/components/register/ArtistSelection.tsx
+++ b/app/src/components/register/ArtistSelection.tsx
@@ -18,8 +18,8 @@ const ArtistSelection: React.FC = () => {
       for (let i = 1; i <= total; i++) {
         const hash: string = await Artists.methods.getArtist(i).call();
         const hashResponse = await fetch(hash);
-        let artist = await hashResponse.json();
-        artist['id'] = i;
+        const artist = await hashResponse.json();
+        artist.id = i;
         artists.push(artist);
       }
 

--- a/app/src/components/register/ArtistSelection.tsx
+++ b/app/src/components/register/ArtistSelection.tsx
@@ -18,7 +18,8 @@ const ArtistSelection: React.FC = () => {
       for (let i = 1; i <= total; i++) {
         const hash: string = await Artists.methods.getArtist(i).call();
         const hashResponse = await fetch(hash);
-        const artist = await hashResponse.json();
+        let artist = await hashResponse.json();
+        artist['id'] = i;
         artists.push(artist);
       }
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a feature/bugfix branch** (right side). Don't request from master!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description

Now have the option to use an ENS username when creating a new artist. If this is a valid ENS, then we store the corresponding address as the new artist's wallet, if it isn't we complain and show a popup saying that we couldn't find an account for that ENS. If you leave this field blank, a new web3 account is created, and the public key of this account is stored as the wallet of the artist.

Additionally fixed a bug where artist selection was using the id field from the preset artists' Json, which newly registered artists did not have, and could not ever have.

### Checklist
* [x] Have you done your changes on a separate branch. Branches MUST have descriptive names that start with either the `fix/` or `feature/` prefixes. Good examples are: `fix/signin-loop` or `feature/pr-templates`.
* [x] Have you got descriptive commit messages that would make sense if prefixed with "This commit will ..."
* [x] Will you squash when you merge this PR?
