### PR TITLE
Feature/multiple consignment

### DIFF
--- a/app/src/components/ClientArtifacts.tsx
+++ b/app/src/components/ClientArtifacts.tsx
@@ -18,8 +18,6 @@ const ClientArtifacts: React.FC = () => {
   const { accounts } = useWeb3Context();
 
   React.useEffect(() => {
-    const currentAccount = accounts[0];
-
     Consignment.methods.consignedTokenIds()
       .call({
         from: accounts[0],

--- a/app/src/components/ClientArtifacts.tsx
+++ b/app/src/components/ClientArtifacts.tsx
@@ -14,14 +14,16 @@ const ClientArtifacts: React.FC = () => {
   const [numClientArtifacts, setNumClientArtifacts] = React.useState<number>();
   const [tokenIds, setTokenIds] = React.useState<number[]>();
 
-  const { ArtifactRegistry } = useContractContext();
+  const { Consignment } = useContractContext();
   const { accounts } = useWeb3Context();
 
   React.useEffect(() => {
     const currentAccount = accounts[0];
 
-    ArtifactRegistry.methods.getOperatorTokenIds(currentAccount)
-      .call()
+    Consignment.methods.consignedTokenIds()
+      .call({
+        from: accounts[0],
+      })
       .then((tokenIdObjects: any) => {
         const tokenIds: number[] = [];
         tokenIdObjects.map((tid: any) => tokenIds.push(tid));
@@ -31,7 +33,7 @@ const ClientArtifacts: React.FC = () => {
         }
       })
       .catch(console.log);
-  }, [ArtifactRegistry, accounts, numClientArtifacts]);
+  }, [Consignment, accounts, numClientArtifacts]);
 
   if (!numClientArtifacts) {
     return (
@@ -48,6 +50,7 @@ const ClientArtifacts: React.FC = () => {
   const listItems = tokenIds.map((tokenId: number) =>
     <ArtworkItem
       tokenId={tokenId}
+      ownedArtifact={true}
       key={tokenId}
     />,
   );

--- a/app/src/components/ConsignArtifact.tsx
+++ b/app/src/components/ConsignArtifact.tsx
@@ -197,23 +197,21 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
         </Modal.Header>
         <Modal.Body>
           {consigned.length !== 0
-            ? <React.Fragment>
+            && <React.Fragment>
               <p>Directly Consigned to:</p>
               <Col>
                 {directInfo}
               </Col>
               <hr/>
-            </React.Fragment>
-            : null}
+            </React.Fragment>}
           {indirectConsigned.length !== 0
-            ? <React.Fragment>
+            && <React.Fragment>
               <p>Indirectly Consigned to:</p>
               <Col>
                 {indirectInfo}
               </Col>
               <hr/>
-            </React.Fragment>
-            : null}
+            </React.Fragment>}
           <p>Consign Account to Sell</p>
           <Form.Group as={Col} controlId="recipientName">
             <Form.Label>Recipient Name</Form.Label>

--- a/app/src/components/ConsignArtifact.tsx
+++ b/app/src/components/ConsignArtifact.tsx
@@ -31,24 +31,17 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
   const [fields, setFields] = React.useState<ConsignArtifactFormFields>({
     recipientName: '',
   });
-  const [consignedAccount, setConsignedAccount] = React.useState<string>('');
   const [showConsignment, setShowConsignment] = React.useState<boolean>(false);
 
   const { addressFromName } = useNameServiceContext();
-  const { ArtifactRegistry } = useContractContext();
+  const { Consignment } = useContractContext();
   const { accounts } = useWeb3Context();
 
-  React.useEffect(() => {
-    ArtifactRegistry.methods.getApproved(tokenId)
-      .call({ from: accounts[0] })
-      .then((account: string) => setConsignedAccount(account))
-      .catch(console.log);
-  }, [accounts, tokenId, ArtifactRegistry]);
-
   const consign = (address: string): void => {
-    ArtifactRegistry.methods.approve(
-      address,
+    Consignment.methods.consign(
       tokenId,
+      address,
+      30,
     ).send(
       {
         from: accounts[0],
@@ -97,11 +90,6 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
           <Modal.Title>Consignment</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          {consignedAccount !== ZERO_ADDR
-            ? <React.Fragment><p>Consigned to <ENSName address={consignedAccount}/> <br/>
-            You may still register a sale yourself, but doing so will revoke consignment.
-            </p><hr/></React.Fragment>
-            : null}
           <p>Consign Account to Sell</p>
           <Form.Group as={Col} controlId="recipientName">
             <Form.Label>Recipient Name</Form.Label>
@@ -120,9 +108,6 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
           <Button variant="primary" onClick={() => consignArtifactForArtwork()}>
             Consign for Sale
           </Button>
-          {consignedAccount !== ZERO_ADDR
-            ? <Button variant="primary" onClick={revokeConsignment}>Revoke Consignment</Button>
-            : null}
         </Modal.Footer>
       </Modal>
     </>

--- a/app/src/components/ConsignArtifact.tsx
+++ b/app/src/components/ConsignArtifact.tsx
@@ -133,7 +133,13 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
   };
 
   const revokeConsignment = async (address: string): Promise<void> => {
-
+    await Consignment.emthods.revoke(tokenId, address)
+      .send(
+        {
+          from: accounts[0],
+          gasLimit: 6000000,
+        },
+      );
   };
 
   const inputChangeHandler = (event: InputChangeEvent): void => {

--- a/app/src/components/ConsignArtifact.tsx
+++ b/app/src/components/ConsignArtifact.tsx
@@ -32,7 +32,7 @@ type InputChangeEvent = React.FormEvent<any> &
   }
 
 const GENERIC_FEEDBACK = <Form.Control.Feedback>Looks good!</Form.Control.Feedback>;
-//const ZERO_ADDR = '0x0000000000000000000000000000000000000000';
+// const ZERO_ADDR = '0x0000000000000000000000000000000000000000';
 
 const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
   const [fields, setFields] = React.useState<ConsignArtifactFormFields>({
@@ -47,18 +47,18 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
   const { accounts } = useWeb3Context();
 
   React.useEffect(() => {
-    const setConsignedInfo = async () => {
+    const setConsignedInfo = async (): Promise<void> => {
       const consignedAccounts = await Consignment.methods.getConsignmentAddresses(tokenId, accounts[0])
         .call({
-          from: accounts[0]
+          from: accounts[0],
         });
 
       const info = [];
 
-      for (let consignedAccount of consignedAccounts) {
+      for (const consignedAccount of consignedAccounts) {
         const commission = await Consignment.methods.getConsignmentInfo(tokenId, accounts[0], consignedAccount)
           .call({
-            from: accounts[0]
+            from: accounts[0],
           });
 
         info.push({
@@ -75,11 +75,11 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
   const consign = async (address: string, commission: string): Promise<void> => {
     const approved = await ArtifactRegistry.methods.getApproved(tokenId)
       .call({
-        from: accounts[0]
+        from: accounts[0],
       });
 
     if (approved === Consignment._address) {
-      console.log("Consignment");
+      console.log('Consignment');
       await Consignment.methods.consign(
         tokenId,
         address,
@@ -91,7 +91,7 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
         },
       );
     } else {
-      console.log("Init consignment");
+      console.log('Init consignment');
       await ArtifactRegistry.methods.initConsign(
         tokenId,
         address,
@@ -100,8 +100,8 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
         {
           from: accounts[0],
           gasLimit: 6000000,
-        }
-      )
+        },
+      );
     }
   };
 
@@ -137,11 +137,11 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
   };
 
   const listItems = consigned.map((info) => {
-    return <Row>
+    return <Row key={info.account}>
       <ENSName address={info.account}/>
       <p>: Commission: {info.commission}%</p>
       <br/>
-    </Row>
+    </Row>;
   });
 
   return (

--- a/app/src/components/ConsignArtifact.tsx
+++ b/app/src/components/ConsignArtifact.tsx
@@ -100,8 +100,9 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
         from: accounts[0],
       });
 
+    // If the consignment contract is not approved we need to approve
+    // the contract and call the appropriate consignment functions.
     if (approved === Consignment._address) {
-      console.log('Consignment');
       await Consignment.methods.consign(
         tokenId,
         address,
@@ -113,7 +114,6 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
         },
       );
     } else {
-      console.log('Init consignment');
       await ArtifactRegistry.methods.initConsign(
         tokenId,
         address,

--- a/app/src/components/ConsignArtifact.tsx
+++ b/app/src/components/ConsignArtifact.tsx
@@ -49,15 +49,15 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
 
   React.useEffect(() => {
     const getIndirectAccounts = async (account: string): Promise<string[]> => {
-      console.log("getting indirect for " + account);
-      const addresses =  await Consignment.methods.getConsignmentAddresses(tokenId, account)
+      console.log('getting indirect for ' + account);
+      const addresses = await Consignment.methods.getConsignmentAddresses(tokenId, account)
         .call({
           from: accounts[0],
         });
 
       let indirect = addresses;
 
-      for (let address of addresses) {
+      for (const address of addresses) {
         indirect = indirect.concat(await getIndirectAccounts(address));
       }
 
@@ -73,7 +73,7 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
       const info = [];
       let indirect: string[] = [];
 
-      for (let consignedAccount of consignedAccounts) {
+      for (const consignedAccount of consignedAccounts) {
         const commission = await Consignment.methods.getConsignmentInfo(tokenId, accounts[0], consignedAccount)
           .call({
             from: accounts[0],
@@ -176,7 +176,7 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
         </Button>
       </Row>
       <hr/>
-    </>
+    </>;
   });
 
   const indirectInfo = indirectConsigned.map((account) => {
@@ -198,21 +198,21 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
         <Modal.Body>
           {consigned.length !== 0
             ? <React.Fragment>
-                <p>Directly Consigned to:</p>
-                <Col>
-                  {directInfo}
-                </Col>
-                <hr/>
-              </React.Fragment>
+              <p>Directly Consigned to:</p>
+              <Col>
+                {directInfo}
+              </Col>
+              <hr/>
+            </React.Fragment>
             : null}
           {indirectConsigned.length !== 0
             ? <React.Fragment>
-                <p>Indirectly Consigned to:</p>
-                <Col>
-                  {indirectInfo}
-                </Col>
-                <hr/>
-              </React.Fragment>
+              <p>Indirectly Consigned to:</p>
+              <Col>
+                {indirectInfo}
+              </Col>
+              <hr/>
+            </React.Fragment>
             : null}
           <p>Consign Account to Sell</p>
           <Form.Group as={Col} controlId="recipientName">

--- a/app/src/components/ConsignArtifact.tsx
+++ b/app/src/components/ConsignArtifact.tsx
@@ -132,9 +132,9 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
     await consign(recipientAddress, fields.commission);
   };
 
-  // const revokeConsignment = async (): Promise<void> => {
-  //   await consign(ZERO_ADDR);
-  // };
+  const revokeConsignment = async (address: string): Promise<void> => {
+
+  };
 
   const inputChangeHandler = (event: InputChangeEvent): void => {
     const key = event.target.id;
@@ -159,11 +159,18 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
   };
 
   const directInfo = consigned.map((info) => {
-    return <Row key={info.account}>
-      <ENSName address={info.account}/>
-      <p>: Commission: {info.commission}%</p>
-      <br/>
-    </Row>;
+    return <>
+      <Row key={info.account}>
+        <ENSName address={info.account}/>
+        <p>: Commission: {info.commission}%</p>
+      </Row>
+      <Row>
+        <Button variant="danger" size="sm" onClick={() => revokeConsignment(info.account)}>
+          Revoke
+        </Button>
+      </Row>
+      <hr/>
+    </>
   });
 
   const indirectInfo = indirectConsigned.map((account) => {

--- a/app/src/components/ConsignArtifact.tsx
+++ b/app/src/components/ConsignArtifact.tsx
@@ -196,16 +196,16 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
           <Modal.Title>Consignment</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          {consigned.length !== 0
-            && <React.Fragment>
+          {consigned.length !== 0 &&
+            <React.Fragment>
               <p>Directly Consigned to:</p>
               <Col>
                 {directInfo}
               </Col>
               <hr/>
             </React.Fragment>}
-          {indirectConsigned.length !== 0
-            && <React.Fragment>
+          {indirectConsigned.length !== 0 &&
+            <React.Fragment>
               <p>Indirectly Consigned to:</p>
               <Col>
                 {indirectInfo}

--- a/app/src/components/ConsignArtifact.tsx
+++ b/app/src/components/ConsignArtifact.tsx
@@ -133,7 +133,7 @@ const ConsignArtifact: React.FC<ConsignArtifactProps> = ({ tokenId }) => {
   };
 
   const revokeConsignment = async (address: string): Promise<void> => {
-    await Consignment.emthods.revoke(tokenId, address)
+    await Consignment.methods.revoke(tokenId, address)
       .send(
         {
           from: accounts[0],

--- a/app/src/components/TransferArtifact.tsx
+++ b/app/src/components/TransferArtifact.tsx
@@ -54,7 +54,7 @@ const TransferArtifact: React.FC<TransferArtifactProps> = ({ tokenId, metaUri })
   const [submitted, setSubmitted] = React.useState<boolean>(false);
 
   const { addressFromName } = useNameServiceContext();
-  const { ArtifactRegistry } = useContractContext();
+  const { ArtifactRegistry, Consignment } = useContractContext();
   const { accounts } = useWeb3Context();
 
   const saveMetaData = (jsonData: string): Promise<string> => {
@@ -107,7 +107,7 @@ const TransferArtifact: React.FC<TransferArtifactProps> = ({ tokenId, metaUri })
         // only take ARR in country that takes it, and if no sales with this token have occurred
         // no sales → user is the one who registered it → they're the artist, or a gallery representing them
         const takesArr = ARR_LOCATIONS.includes(fields.location) && relevantEvents.length > 0;
-        return ArtifactRegistry.methods.transfer(
+        return Consignment.methods.transfer(
           owner,
           recipientAddress,
           tokenId,

--- a/app/src/components/TransferArtifact.tsx
+++ b/app/src/components/TransferArtifact.tsx
@@ -105,8 +105,6 @@ const TransferArtifact: React.FC<TransferArtifactProps> = ({ tokenId, metaUri })
         from: accounts[0],
       });
 
-
-
     ArtifactRegistry.getPastEvents('RecordSale', eventOptions)
       .then((events: EventData[]) => {
         return events.filter(event => event.returnValues.tokenId === tokenId.toString());

--- a/app/src/components/TransferArtifact.tsx
+++ b/app/src/components/TransferArtifact.tsx
@@ -100,6 +100,13 @@ const TransferArtifact: React.FC<TransferArtifactProps> = ({ tokenId, metaUri })
 
     const eventOptions = { fromBlock: 0 };
 
+    const approved = await ArtifactRegistry.methods.getApproved(tokenId)
+      .call({
+        from: accounts[0],
+      });
+
+
+
     ArtifactRegistry.getPastEvents('RecordSale', eventOptions)
       .then((events: EventData[]) => {
         return events.filter(event => event.returnValues.tokenId === tokenId.toString());
@@ -107,7 +114,10 @@ const TransferArtifact: React.FC<TransferArtifactProps> = ({ tokenId, metaUri })
         // only take ARR in country that takes it, and if no sales with this token have occurred
         // no sales → user is the one who registered it → they're the artist, or a gallery representing them
         const takesArr = ARR_LOCATIONS.includes(fields.location) && relevantEvents.length > 0;
-        return Consignment.methods.transfer(
+
+        const contract = approved === Consignment._address ? Consignment : ArtifactRegistry;
+
+        return contract.methods.transfer(
           owner,
           recipientAddress,
           tokenId,

--- a/app/src/helper/contracts.ts
+++ b/app/src/helper/contracts.ts
@@ -3,10 +3,12 @@ export type ArtifactApplication = any;
 export type ArtifactRegistry = any;
 export type Artists = any;
 export type Ens = any;
+export type Consignment = any;
 
 export interface ContractListType {
   Governance: Governance;
   ArtifactApplication: ArtifactApplication;
   ArtifactRegistry: ArtifactRegistry;
   Artists: Artists;
+  Consignment: Consignment;
 }

--- a/app/src/providers/ContractProvider.tsx
+++ b/app/src/providers/ContractProvider.tsx
@@ -7,6 +7,7 @@ import Governance from '../contracts/Governance.json';
 import ArtifactApplication from '../contracts/ArtifactApplication.json';
 import ArtifactRegistry from '../contracts/ArtifactRegistry.json';
 import Artists from '../contracts/Artists.json';
+import Consignment from '../contracts/Consignment.json';
 
 import { ContractListType } from '../helper/contracts';
 
@@ -23,17 +24,20 @@ export const ContractProvider: React.FC = ({ children }) => {
       const applicationAddr = await addressFromName('application.artistry.test');
       const registryAddr = await addressFromName('registry.artistry.test');
       const artistsAddr = await addressFromName('artists.artistry.test');
+      const consignmentAddr = await addressFromName('consignment.artistry.test');
 
       const governance = new web3.eth.Contract(Governance.abi, governanceAddr);
       const artifactApplication = new web3.eth.Contract(ArtifactApplication.abi, applicationAddr);
       const artifactRegistry = new web3.eth.Contract(ArtifactRegistry.abi, registryAddr);
       const artists = new web3.eth.Contract(Artists.abi, artistsAddr);
+      const consignment = new web3.eth.Contract(Consignment.abi, consignmentAddr);
 
       const contracts = {
         Governance: governance,
         ArtifactApplication: artifactApplication,
         ArtifactRegistry: artifactRegistry,
         Artists: artists,
+        Consignment: consignment,
       };
 
       setContracts(contracts);

--- a/app/src/providers/SessionProvider.tsx
+++ b/app/src/providers/SessionProvider.tsx
@@ -14,15 +14,10 @@ export const DACS_DEFAULT: User = {
   nickname: 'Anna Doe',
   img: 'https://mdbootstrap.com/img/Photos/Avatars/img%20%2820%29.jpg',
   role: 'DACS',
-  address: '0xDf08F82De32B8d460adbE8D72043E3a7e25A3B39',
-  name: 'dac.artistry.test',
-};
-
-export const DACS_RINKEBY: User = {
-  nickname: 'Anna Doe',
-  img: 'https://mdbootstrap.com/img/Photos/Avatars/img%20%2820%29.jpg',
-  role: 'DACS',
-  address: '0x594cd738A5e99134De9DE21f253eD1Be4eb27F3e',
+  address: [
+    '0xDf08F82De32B8d460adbE8D72043E3a7e25A3B39',
+    '0x594cd738A5e99134De9DE21f253eD1Be4eb27F3e'
+  ],
   name: 'dac.artistry.test',
 };
 
@@ -30,7 +25,11 @@ export const DEAL_DEFAULT: User = {
   nickname: 'Gallery',
   img: 'https://www.cavan-arts.com/uploads/1/2/2/7/122790076/img-4071_orig.jpg',
   role: 'DEAL',
-  address: '0xdE164a54b441808DA5C448D85Ba2F0F6e271CC36',
+  address: [
+    '0xdE164a54b441808DA5C448D85Ba2F0F6e271CC36',
+    '0x97A3FC5Ee46852C1Cf92A97B7BaD42F2622267cC',
+    '0xce42bdB34189a93c55De250E011c68FaeE374Dd3',
+  ],
   name: 'gallery.artistry.test',
 };
 
@@ -38,7 +37,7 @@ export const NATASHA: User = {
   nickname: 'Natasha',
   img: 'https://mdbootstrap.com/img/Photos/Avatars/img%20(17).jpg',
   role: 'ARTIST',
-  address: '0xc70eAc1d854E51FaFC7a487086624E79cEE6e843',
+  address: ['0xc70eAc1d854E51FaFC7a487086624E79cEE6e843'],
   name: 'natasha.artistry.test',
 };
 
@@ -46,7 +45,7 @@ export const BUYER_DEFAULT: User = {
   nickname: 'Buyer',
   img: 'https://mdbootstrap.com/img/Photos/Avatars/img%20(9).jpg',
   role: 'COLLECTOR',
-  address: '0x1bf078753937FB3e569C4c9724654d10cc8A7Fd7',
+  address: ['0x1bf078753937FB3e569C4c9724654d10cc8A7Fd7'],
   name: 'buyer.artistry.test',
 };
 
@@ -54,7 +53,7 @@ export interface User {
   img: string;
   nickname: string;
   role: string;
-  address?: string;
+  address?: string[];
   name: string;
 }
 
@@ -74,18 +73,18 @@ export const SessionProvider: React.FC = ({ children }) => {
   const [user, setUser] = React.useState<User>(defaultUser);
   const [gotUser, setGotUser] = React.useState<boolean>(false);
 
-  const users = [DACS_DEFAULT, DACS_RINKEBY, DEAL_DEFAULT, NATASHA, BUYER_DEFAULT];
+  const users = [DACS_DEFAULT, DEAL_DEFAULT, NATASHA, BUYER_DEFAULT];
 
   React.useEffect(() => {
     let curUser: User = defaultUser;
     for (const user of users) {
-      if (user.address === address) {
+      if (user.address && user.address.includes(address)) {
         curUser = user;
         break;
       }
     }
 
-    curUser.address = address;
+    curUser.address = [address];
 
     setUser(curUser);
 

--- a/app/src/providers/SessionProvider.tsx
+++ b/app/src/providers/SessionProvider.tsx
@@ -16,7 +16,7 @@ export const DACS_DEFAULT: User = {
   role: 'DACS',
   address: [
     '0xDf08F82De32B8d460adbE8D72043E3a7e25A3B39',
-    '0x594cd738A5e99134De9DE21f253eD1Be4eb27F3e'
+    '0x594cd738A5e99134De9DE21f253eD1Be4eb27F3e',
   ],
   name: 'dac.artistry.test',
 };

--- a/contracts/ArtifactRegistry.sol
+++ b/contracts/ArtifactRegistry.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/drafts/Counters.sol";
 
 import { IArtifactRegistry } from "./interfaces/IArtifactRegistry.sol";
 import { IGovernance } from "./interfaces/IGovernance.sol";
+import { Consignment } from "./Consignment.sol";
 import { ERC721ApprovalEnumerable } from "./ERC721ApprovalEnumerable.sol";
 
 /**
@@ -20,6 +21,7 @@ contract ArtifactRegistry is IArtifactRegistry, Ownable, ERC721Full, ERC721Appro
   using Counters for Counters.Counter;
 
   IGovernance public governance;
+  address public consignmentAddress;
 
   Counters.Counter public _tokenId;
   mapping (uint256 => Artifact) public artifacts;
@@ -27,6 +29,10 @@ contract ArtifactRegistry is IArtifactRegistry, Ownable, ERC721Full, ERC721Appro
   constructor(address owner, IGovernance _governance) public ERC721Full("Artifact", "ART") {
     _transferOwnership(owner);
     governance = _governance;
+  }
+
+  function setConsignment(address _consignmentAddress) public {
+    consignmentAddress = _consignmentAddress;
   }
 
   function mint(address who, Artifact memory _artifact) public returns (uint256) {
@@ -39,6 +45,8 @@ contract ArtifactRegistry is IArtifactRegistry, Ownable, ERC721Full, ERC721Appro
 
     _mint(who, newTokenId);
     _setTokenURI(newTokenId, _artifact.metaUri);
+
+    approve(consignmentAddress, newTokenId);
 
     return newTokenId;
   }

--- a/contracts/ArtifactRegistry.sol
+++ b/contracts/ArtifactRegistry.sol
@@ -21,7 +21,7 @@ contract ArtifactRegistry is IArtifactRegistry, Ownable, ERC721Full, ERC721Appro
   using Counters for Counters.Counter;
 
   IGovernance public governance;
-  address public consignmentAddress;
+  Consignment public consignment;
 
   Counters.Counter public _tokenId;
   mapping (uint256 => Artifact) public artifacts;
@@ -31,8 +31,8 @@ contract ArtifactRegistry is IArtifactRegistry, Ownable, ERC721Full, ERC721Appro
     governance = _governance;
   }
 
-  function setConsignment(address _consignmentAddress) public {
-    consignmentAddress = _consignmentAddress;
+  function setConsignment(Consignment _consignment) public {
+    consignment = _consignment;
   }
 
   function mint(address who, Artifact memory _artifact) public returns (uint256) {
@@ -46,9 +46,13 @@ contract ArtifactRegistry is IArtifactRegistry, Ownable, ERC721Full, ERC721Appro
     _mint(who, newTokenId);
     _setTokenURI(newTokenId, _artifact.metaUri);
 
-    approve(consignmentAddress, newTokenId);
-
     return newTokenId;
+  }
+
+  function initConsign(uint256 tokenId, address who, uint8 commission) public {
+    approve(address(consignment), tokenId);
+
+    consignment.consign(tokenId, who, commission);
   }
 
   function getArtifactForToken(uint256 tokenId) public view returns (address, string memory) {

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -47,7 +47,7 @@ contract Consignment {
       ConsignmentInfo memory consignmentInfo = consignmentInfos[i];
 
       address consignee = consignmentInfo.consignee;
-      uint256[] memory consignedTokens = consigned[consignee];
+      uint256[] storage consignedTokens = consigned[consignee];
 
       for (uint j = 0; j < consignedTokens.length; j++) {
         if (consignedTokens[j] == tokenId) {
@@ -55,8 +55,6 @@ contract Consignment {
           break;
         }
       }
-
-      consigned[consignee] = consignedTokens;
     }
 
     delete consignments[tokenId];
@@ -85,7 +83,7 @@ contract Consignment {
 
   function revoke(uint256 tokenId, address who) public authorized(tokenId) {
     ConsignmentInfo[] storage consignmentInfos = consignments[tokenId];
-    
+
     for (uint i = 0; i < consignmentInfos.length; i++) {
       ConsignmentInfo storage info = consignmentInfos[i];
       if (info.valid && info.consignee == who) {

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -101,7 +101,7 @@ contract Consignment {
       ConsignmentInfo storage info = consignmentInfos[i];
       if (info.valid && info.consigner == who) {
         info.valid = false;
-        revokeHelper(tokenId, info.consignee);
+        revokeChildren(tokenId, info.consignee);
       }
 
       uint256[] memory consignedTokens = consigned[who];

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -105,6 +105,18 @@ contract Consignment {
     return addresses;
   }
 
+  function getConsignmentInfo(uint256 tokenId, address consigner, address consignee) public view authorized(tokenId) returns (uint8 commission) {
+    ConsignmentInfo[] memory consignmentInfos = consignments[tokenId];
+
+    for (uint i = 0; i < consignmentInfos.length; i++) {
+      if (consignmentInfos[i].consigner == consigner && consignmentInfos[i].consignee == consignee) {
+        return consignmentInfos[i].commission;
+      }
+    }
+
+    return 0;
+  }
+
   function isConsigned(uint256 tokenId, address who) public view returns (bool) {
     address tokenOwner = registry.ownerOf(tokenId);
     ConsignmentInfo[] memory consignmentInfos = consignments[tokenId];

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -58,4 +58,17 @@ contract Consignment {
 
     consignments[who] = consignmentInfo;
   }
+
+  function isConsigned(uint256 tokenId, address who) public view returns(bool) {
+    address tokenOwner = registry.ownerOf(tokenId);
+
+    ConsignmentInfo memory consignmentInfo;
+
+    while (who != address(0) && who != tokenOwner) {
+      consignmentInfo = consignments[who];
+      who = consignmentInfo.consigner;
+    }
+
+    return who == tokenOwner;
+  }
 }

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -29,12 +29,12 @@ contract Consignment {
     address who = msg.sender;
     ConsignmentInfo memory consignmentInfo;
 
-    while (who != address(0) && who != tokenOwner) {
+    while (who != address(0) && who != tokenOwner && who != address(registry)) {
       consignmentInfo = consignments[who];
       who = consignmentInfo.consigner;
     }
 
-    require(tokenOwner == who, "Consignment::authorized: Account not authorized");
+    require(tokenOwner == who || address(registry) == who, "Consignment::authorized: Account not authorized");
     _;
   }
 

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -23,17 +23,17 @@ contract Consignment {
   mapping (address => ConsignmentInfo) public consignments;
 
   modifier authorized(uint256 tokenId) {
-    address who = msg.sender;
-    ConsignmentInfo memory consignmentInfo = consignments[who];
-    address consigner = consignmentInfo.consigner;
+    address tokenOwner = registry.ownerOf(tokenId);
 
-    while (consigner != address(0)) {
-      who = consigner;
+    address who = msg.sender;
+    ConsignmentInfo memory consignmentInfo;
+
+    while (who != address(0) && who != tokenOwner) {
       consignmentInfo = consignments[who];
-      consigner = consignmentInfo.consigner;
+      who = consignmentInfo.consigner;
     }
 
-    require(registry.ownerOf(tokenId) == consigner);
+    require(tokenOwner == who, "Consignment::authorized: Account not authorized");
     _;
   }
 

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -91,10 +91,10 @@ contract Consignment {
       }
     }
 
-    revokeHelper(tokenId, who);
+    revokeChildren(tokenId, who);
   }
 
-  function revokeHelper(uint256 tokenId, address who) private {
+  function revokeChildren(uint256 tokenId, address who) private {
     ConsignmentInfo[] storage consignmentInfos = consignments[tokenId];
 
     for (uint i = 0; i < consignmentInfos.length; i++) {

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -46,8 +46,14 @@ contract Consignment {
 
     ConsignmentInfo memory consignmentInfo;
 
-    consignmentInfo.consigner = msg.sender;
+    address consigner = msg.sender;
+
+    if (consigner == address(registry)) {
+      consigner = address(registry.ownerOf(tokenId));
+    }
+
     consignmentInfo.consignee = who;
+    consignmentInfo.consigner = consigner;
     consignmentInfo.commission = commission;
 
     consignments[tokenId].push(consignmentInfo);
@@ -71,10 +77,9 @@ contract Consignment {
 
     for (uint i = 0; i < consignmentInfos.length; i++) {
       if (consignmentInfos[i].consigner == who) {
-        addresses[count] = consignmentInfos[count].consignee;
+        addresses[count] = consignmentInfos[i].consignee;
         count = count + 1;
       }
-
     }
 
     return addresses;

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -55,13 +55,13 @@ contract Consignment {
     consigned[who].push(tokenId);
   }
 
-  function getConsignmentAddresses(uint256 tokenId) public view authorized(tokenId) returns (address[] memory) {
+  function getConsignmentAddresses(uint256 tokenId, address who) public view authorized(tokenId) returns (address[] memory) {
     ConsignmentInfo[] memory consignmentInfos = consignments[tokenId];
 
     uint count = 0;
 
     for (uint i = 0; i < consignmentInfos.length; i++) {
-      if (consignmentInfos[i].consigner == msg.sender) {
+      if (consignmentInfos[i].consigner == who) {
         count = count + 1;
       }
     }
@@ -70,7 +70,7 @@ contract Consignment {
     count = 0;
 
     for (uint i = 0; i < consignmentInfos.length; i++) {
-      if (consignmentInfos[i].consigner == msg.sender) {
+      if (consignmentInfos[i].consigner == who) {
         addresses[count] = consignmentInfos[count].consignee;
         count = count + 1;
       }

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -42,6 +42,8 @@ contract Consignment {
   }
 
   function consign(uint256 tokenId, address who, uint8 commission) public authorized(tokenId) {
+    require(!isConsigned(tokenId, who), "Consignment::consign: Account is already authorized");
+
     ConsignmentInfo memory consignmentInfo;
 
     consignmentInfo.consigner = msg.sender;

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -21,6 +21,7 @@ contract Consignment {
   }
 
   mapping (address => ConsignmentInfo) public consignments;
+  mapping (address => uint256[]) public consigned;
 
   modifier authorized(uint256 tokenId) {
     address tokenOwner = registry.ownerOf(tokenId);
@@ -57,9 +58,11 @@ contract Consignment {
     consignmentInfo.commission = commission;
 
     consignments[who] = consignmentInfo;
+
+    consigned[who].push(tokenId);
   }
 
-  function isConsigned(uint256 tokenId, address who) public view returns(bool) {
+  function isConsigned(uint256 tokenId, address who) public view returns (bool) {
     address tokenOwner = registry.ownerOf(tokenId);
 
     ConsignmentInfo memory consignmentInfo;
@@ -70,5 +73,9 @@ contract Consignment {
     }
 
     return who == tokenOwner;
+  }
+
+  function consignedTokenIds() public view returns (uint256[] memory) {
+    return consigned[msg.sender];
   }
 }

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -1,0 +1,61 @@
+pragma solidity 0.5.12;
+pragma experimental ABIEncoderV2;
+
+import { IArtifactRegistry } from "./interfaces/IArtifactRegistry.sol";
+
+/**
+ * @title Consignment
+ * @dev The contract in charge of delegating consignment to dealers
+ */
+contract Consignment {
+
+  IArtifactRegistry public registry;
+
+  struct ConsignmentInfo {
+    address consigner;
+    uint8 commission;
+  }
+
+  constructor(IArtifactRegistry _registry) public {
+    registry = _registry;
+  }
+
+  mapping (address => ConsignmentInfo) public consignments;
+
+  modifier authorized(uint256 tokenId) {
+    address who = msg.sender;
+    ConsignmentInfo memory consignmentInfo = consignments[who];
+    address consigner = consignmentInfo.consigner;
+
+    while (consigner != address(0)) {
+      who = consigner;
+      consignmentInfo = consignments[who];
+      consigner = consignmentInfo.consigner;
+    }
+
+    require(registry.ownerOf(tokenId) == consigner);
+    _;
+  }
+
+  function transfer(
+    address who,
+    address recipient,
+    uint256 tokenId,
+    string memory metaUri,
+    uint price,
+    string memory location,
+    string memory date,
+    bool arr
+  ) public authorized(tokenId) {
+    registry.transfer(who, recipient, tokenId, metaUri, price, location, date, arr);
+  }
+
+  function consign(uint256 tokenId, address who, uint8 commission) public authorized(tokenId) {
+    ConsignmentInfo memory consignmentInfo;
+
+    consignmentInfo.consigner = msg.sender;
+    consignmentInfo.commission = commission;
+
+    consignments[who] = consignmentInfo;
+  }
+}

--- a/contracts/Consignment.sol
+++ b/contracts/Consignment.sol
@@ -39,6 +39,26 @@ contract Consignment {
     bool arr
   ) public authorized(tokenId) {
     registry.transfer(who, recipient, tokenId, metaUri, price, location, date, arr);
+
+    ConsignmentInfo[] memory consignmentInfos = consignments[tokenId];
+
+    for (uint i = 0; i < consignmentInfos.length; i++) {
+      ConsignmentInfo memory consignmentInfo = consignmentInfos[i];
+
+      address consignee = consignmentInfo.consignee;
+      uint256[] memory consignedTokens = consigned[consignee];
+
+      for (uint j = 0; j < consignedTokens.length; j++) {
+        if (consignedTokens[j] == tokenId) {
+          delete consignedTokens[j];
+          break;
+        }
+      }
+
+      consigned[consignee] = consignedTokens;
+    }
+
+    delete consignments[tokenId];
   }
 
   function consign(uint256 tokenId, address who, uint8 commission) public authorized(tokenId) {
@@ -107,6 +127,26 @@ contract Consignment {
   }
 
   function consignedTokenIds() public view returns (uint256[] memory) {
-    return consigned[msg.sender];
+    uint256[] memory ids = consigned[msg.sender];
+
+    uint count = 0;
+
+    for (uint i = 0; i < ids.length; i++) {
+      if (ids[i] != 0) {
+        count = count + 1;
+      }
+    }
+
+    uint256[] memory validIds = new uint256[](count);
+    count = 0;
+
+    for (uint i = 0; i < ids.length; i++) {
+      if (ids[i] != 0) {
+        validIds[count] = ids[i];
+        count = count + 1;
+      }
+    }
+
+    return validIds;
   }
 }

--- a/migrations/9_deploy_consignment.js
+++ b/migrations/9_deploy_consignment.js
@@ -1,0 +1,37 @@
+const ArtifactRegistry = artifacts.require('ArtifactRegistry');
+const Consignment = artifacts.require('Consignment');
+const ENSResolver = artifacts.require('ENSResolver');
+
+const newLabel = require('./helper/LoggedRegistration');
+
+module.exports = async (deployer, network, accounts) => {
+  const owner = getOwner(network, accounts);
+
+  const registry = await ArtifactRegistry.deployed();
+  await deployer.deploy(Consignment, registry.address);
+
+  await newLabel(
+    'consignment',
+    owner,
+    await ENSResolver.deployed(),
+    await Consignment.deployed(),
+    network,
+    artifacts,
+    web3,
+  );
+};
+
+const getOwner = (network, accounts) => {
+  switch (network) {
+  case 'development':
+  case 'test':
+  case 'soliditycoverage':
+  case 'ganache':
+    return accounts[0];
+  case 'rinkeby':
+  case 'rinkeby-fork':
+    return process.env.ACCOUNT_ADDRESS;
+  default:
+    throw new Error('No owner selected for this network');
+  }
+};

--- a/migrations/9_deploy_consignment.js
+++ b/migrations/9_deploy_consignment.js
@@ -9,6 +9,7 @@ module.exports = async (deployer, network, accounts) => {
 
   const registry = await ArtifactRegistry.deployed();
   await deployer.deploy(Consignment, registry.address);
+  await registry.setConsignment(Consignment.address);
 
   await newLabel(
     'consignment',

--- a/migrations/9_deploy_consignment.js
+++ b/migrations/9_deploy_consignment.js
@@ -9,13 +9,14 @@ module.exports = async (deployer, network, accounts) => {
 
   const registry = await ArtifactRegistry.deployed();
   await deployer.deploy(Consignment, registry.address);
-  await registry.setConsignment(Consignment.address);
+  const instance = await Consignment.deployed();
+  await registry.setConsignment(instance.address);
 
   await newLabel(
     'consignment',
     owner,
     await ENSResolver.deployed(),
-    await Consignment.deployed(),
+    instance,
     network,
     artifacts,
     web3,

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -217,5 +217,15 @@ contract('Consignment', async accounts => {
         'Consignment::authorized: Account not authorized'
       );
     });
+
+    it('transfer removes consignment', async () => {
+      await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
+      await instance.consign(tokenId, accounts[6], commission, { from: accounts[1] });
+
+      await transfer(accounts[6]);
+
+      const result = await instance.consignedTokenIds({ from: accounts[6] });
+      expect(result).to.be.eql([])
+    });
   });
 });

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -24,8 +24,6 @@ contract('Consignment', async accounts => {
       await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
       const balance = await registry.balanceOf(tokenOwner);
       tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
-
-      registry.approve(instance.address, tokenId);
     });
 
     it('token owner can consign', async () => {
@@ -56,8 +54,6 @@ contract('Consignment', async accounts => {
       await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
       const balance = await registry.balanceOf(tokenOwner);
       tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
-
-      registry.approve(instance.address, tokenId);
     });
 
     it('token owner is consigned', async () => {
@@ -91,8 +87,6 @@ contract('Consignment', async accounts => {
       await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
       const balance = await registry.balanceOf(tokenOwner);
       tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
-
-      registry.approve(instance.address, tokenId);
     });
 
     it('initially have zero consigned tokens', async () => {

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -173,7 +173,7 @@ contract('Consignment', async accounts => {
     });
 
     it('returns 0 for invalid params', async () => {
-      const result = await instance.getConsignmentInfo(tokenId tokenOwner, accounts[8]);
+      const result = await instance.getConsignmentInfo(tokenId, tokenOwner, accounts[8]);
 
       expect(result.toNumber()).be.eql(0);
     });

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -225,7 +225,7 @@ contract('Consignment', async accounts => {
       await transfer(accounts[6]);
 
       const result = await instance.consignedTokenIds({ from: accounts[6] });
-      expect(result).to.be.eql([])
+      expect(result).to.be.eql([]);
     });
   });
 });

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -48,6 +48,17 @@ contract('Consignment', async accounts => {
         'Consignment::authorized: Account not authorized'
       );
     });
+
+    it('cannot consign to consigned account', async () => {
+      await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
+      await instance.consign(tokenId, accounts[2], commission, { from: accounts[1] });
+      await instance.consign(tokenId, accounts[3], commission, { from: accounts[2] });
+
+      await expectRevert(
+        instance.consign(tokenId, tokenOwner, commission, { from: accounts[3] }),
+        'Consignment::consign: Account is already authorized'
+      );
+    });
   });
 
   describe('consigned', async () => {

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -45,7 +45,7 @@ contract('Consignment', async accounts => {
     it('non-consigned account cannot consign', async () => {
       await expectRevert(
         instance.consign(tokenId, accounts[4], commission, { from: accounts[5] }),
-        'Consignment::authorized: Account not authorized'
+        'Consignment::authorized: Account not authorized',
       );
     });
 
@@ -56,7 +56,7 @@ contract('Consignment', async accounts => {
 
       await expectRevert(
         instance.consign(tokenId, tokenOwner, commission, { from: accounts[3] }),
-        'Consignment::consign: Account is already authorized'
+        'Consignment::consign: Account is already authorized',
       );
     });
   });
@@ -244,7 +244,7 @@ contract('Consignment', async accounts => {
         location,
         date,
         false,
-        { from: account }
+        { from: account },
       );
     };
 
@@ -284,7 +284,7 @@ contract('Consignment', async accounts => {
     it('non-authorized account cannot transfer', async () => {
       await expectRevert(
         transfer(accounts[5]),
-        'Consignment::authorized: Account not authorized'
+        'Consignment::authorized: Account not authorized',
       );
     });
 

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -129,7 +129,7 @@ contract('Consignment', async accounts => {
         false,
         { from: account }
       );
-    }
+    };
 
     beforeEach(async () => {
       await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -254,7 +254,8 @@ contract('Consignment', async accounts => {
       tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
     });
 
-    it('token owner can transfer', async () => {
+    it('token owner can transfer if consignment is approved', async () => {
+      await registry.approve(instance.address, tokenId);
       await transfer(tokenOwner);
 
       const owner = await registry.ownerOf(tokenId);

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -252,8 +252,6 @@ contract('Consignment', async accounts => {
       await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
       const balance = await registry.balanceOf(tokenOwner);
       tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
-
-      registry.approve(instance.address, tokenId);
     });
 
     it('token owner can transfer', async () => {
@@ -264,7 +262,7 @@ contract('Consignment', async accounts => {
     });
 
     it('authorized account can transfer', async () => {
-      await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
+      await registry.initConsign(tokenId, accounts[1], commission, { from: tokenOwner });
 
       await transfer(accounts[1]);
 
@@ -273,7 +271,7 @@ contract('Consignment', async accounts => {
     });
 
     it('chained authorized account can transfer', async () => {
-      await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
+      await registry.initConsign(tokenId, accounts[1], commission, { from: tokenOwner });
       await instance.consign(tokenId, accounts[2], commission, { from: accounts[1] });
 
       await transfer(accounts[2]);
@@ -290,7 +288,7 @@ contract('Consignment', async accounts => {
     });
 
     it('transfer removes consignment', async () => {
-      await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
+      await registry.initConsign(tokenId, accounts[1], commission, { from: tokenOwner });
       await instance.consign(tokenId, accounts[6], commission, { from: accounts[1] });
 
       await transfer(accounts[6]);

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -17,24 +17,29 @@ contract('Consignment', async accounts => {
     const governance = await Governance.deployed();
     registry = await ArtifactRegistry.new(tokenOwner, governance.address, { from: tokenOwner });
     instance = await Consignment.new(registry.address);
-
-    await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
-    const balance = await registry.balanceOf(tokenOwner);
-    tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
-
-    registry.approve(instance.address, tokenId);
   });
 
   describe('authorize', async () => {
+    beforeEach(async () => {
+      await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
+      const balance = await registry.balanceOf(tokenOwner);
+      tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
+
+      registry.approve(instance.address, tokenId);
+    });
+
     it('token owner can consign', async () => {
       await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
     });
 
     it('consigned account can consign', async () => {
+      await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
       await instance.consign(tokenId, accounts[2], commission, { from: accounts[1] });
     });
 
     it('chained consigned account can consign', async () => {
+      await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
+      await instance.consign(tokenId, accounts[2], commission, { from: accounts[1] });
       await instance.consign(tokenId, accounts[3], commission, { from: accounts[2] });
     });
 
@@ -47,20 +52,64 @@ contract('Consignment', async accounts => {
   });
 
   describe('transfer', async () => {
-    it('token owner can transfer', async () => {
+    const buyer = accounts[7];
+    const metaUri = 'metaUri';
+    const location = 'location';
+    const date = 'date';
 
+    const transfer = async (account) => {
+      await instance.transfer(
+        tokenOwner,
+        buyer,
+        tokenId,
+        metaUri,
+        100,
+        location,
+        date,
+        false,
+        { from: account }
+      );
+    }
+
+    beforeEach(async () => {
+      await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
+      const balance = await registry.balanceOf(tokenOwner);
+      tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
+
+      registry.approve(instance.address, tokenId);
+    });
+
+    it('token owner can transfer', async () => {
+      await transfer(tokenOwner);
+
+      const owner = await registry.ownerOf(tokenId);
+      expect(owner).to.be.eql(buyer);
     });
 
     it('authorized account can transfer', async () => {
+      await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
 
+      await transfer(accounts[1]);
+
+      const owner = await registry.ownerOf(tokenId);
+      expect(owner).to.be.eql(buyer);
     });
 
     it('chained authorized account can transfer', async () => {
+      await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
+      await instance.consign(tokenId, accounts[2], commission, { from: accounts[1] });
 
+      await transfer(accounts[2]);
+
+      const owner = await registry.ownerOf(tokenId);
+      expect(owner).to.be.eql(buyer);
     });
 
     it('non-authorized account cannot transfer', async () => {
-
+      await expectRevert(
+        transfer(accounts[5]),
+        'Consignment::authorized: Account not authorized'
+      );
     });
   });
 });

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -171,6 +171,12 @@ contract('Consignment', async accounts => {
 
       expect(result.toNumber()).be.eql(15);
     });
+
+    it('returns 0 for invalid params', async () => {
+      const result = await instance.getConsignmentInfo(99999, tokenOwner, accounts[8]);
+
+      expect(result.toNumber()).be.eql(0);
+    });
   });
 
   describe('revoke', async () => {

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -17,6 +17,7 @@ contract('Consignment', async accounts => {
     const governance = await Governance.deployed();
     registry = await ArtifactRegistry.new(tokenOwner, governance.address, { from: tokenOwner });
     instance = await Consignment.new(registry.address);
+    await registry.setConsignment(instance.address);
   });
 
   describe('consign', async () => {
@@ -98,6 +99,14 @@ contract('Consignment', async accounts => {
       await instance.consign(tokenId, accounts[8], commission, { from: tokenOwner });
 
       const result = await instance.consignedTokenIds({ from: accounts[8] });
+      expect(result).be.eql([tokenId]);
+    });
+
+    it('will show all consigned tokens for chained account', async () => {
+      await instance.consign(tokenId, accounts[8], commission, { from: tokenOwner });
+      await instance.consign(tokenId, accounts[7], commission, { from: accounts[8] });
+
+      const result = await instance.consignedTokenIds({ from: accounts[7] });
       expect(result).be.eql([tokenId]);
     });
   });

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -86,6 +86,28 @@ contract('Consignment', async accounts => {
     });
   });
 
+  describe('get consigned tokens', async () => {
+    beforeEach(async () => {
+      await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
+      const balance = await registry.balanceOf(tokenOwner);
+      tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
+
+      registry.approve(instance.address, tokenId);
+    });
+
+    it('initially have zero consigned tokens', async () => {
+      const result = await instance.consignedTokenIds({ from: accounts[8] });
+      expect(result).be.eql([]);
+    });
+
+    it('will show all consigned tokens', async () => {
+      await instance.consign(tokenId, accounts[8], commission, { from: tokenOwner });
+
+      const result = await instance.consignedTokenIds({ from: accounts[8] });
+      expect(result).be.eql([tokenId]);
+    });
+  });
+
   describe('transfer', async () => {
     const buyer = accounts[7];
     const metaUri = 'metaUri';

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -132,7 +132,7 @@ contract('Consignment', async accounts => {
     it('can grab single consigned address for a tokenId', async () => {
       await instance.consign(tokenId, accounts[8], commission, { from: tokenOwner });
 
-      const result = await instance.getConsignmentAddresses(tokenId, { from: tokenOwner });
+      const result = await instance.getConsignmentAddresses(tokenId, tokenOwner);
 
       expect(result[0]).be.eql(accounts[8]);
     });
@@ -141,7 +141,7 @@ contract('Consignment', async accounts => {
       await instance.consign(tokenId, accounts[8], commission, { from: tokenOwner });
       await instance.consign(tokenId, accounts[7], commission, { from: tokenOwner });
 
-      const result = await instance.getConsignmentAddresses(tokenId, { from: tokenOwner });
+      const result = await instance.getConsignmentAddresses(tokenId, tokenOwner);
 
       expect(result[0]).be.eql(accounts[8]);
       expect(result[1]).be.eql(accounts[7]);
@@ -151,7 +151,7 @@ contract('Consignment', async accounts => {
       await instance.consign(tokenId, accounts[8], commission, { from: tokenOwner });
       await instance.consign(tokenId, accounts[7], commission, { from: accounts[8] });
 
-      const result = await instance.getConsignmentAddresses(tokenId, { from: tokenOwner });
+      const result = await instance.getConsignmentAddresses(tokenId, tokenOwner);
 
       expect(result[0]).be.eql(accounts[8]);
     });

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -111,20 +111,38 @@ contract('Consignment', async accounts => {
     });
   });
 
-  describe('get consignment info', async () => {
+  describe('get consignment addresses', async () => {
     beforeEach(async () => {
       await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
       const balance = await registry.balanceOf(tokenOwner);
       tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
     });
 
-    it('can grab consigned info for a tokenId', async () => {
+    it('can grab single consigned address for a tokenId', async () => {
       await instance.consign(tokenId, accounts[8], commission, { from: tokenOwner });
 
-      const result = await instance.getConsignmentInfo(tokenId, { from: accounts[8] });
+      const result = await instance.getConsignmentAddresses(tokenId, { from: tokenOwner });
 
-      expect(result[0]).be.eql(accounts[0]);
-      expect(result[1].toNumber()).be.eql(commission);
+      expect(result[0]).be.eql(accounts[8]);
+    });
+
+    it('can grab multiple consigned address for a tokenId', async () => {
+      await instance.consign(tokenId, accounts[8], commission, { from: tokenOwner });
+      await instance.consign(tokenId, accounts[7], commission, { from: tokenOwner });
+
+      const result = await instance.getConsignmentAddresses(tokenId, { from: tokenOwner });
+
+      expect(result[0]).be.eql(accounts[8]);
+      expect(result[1]).be.eql(accounts[7]);
+    });
+
+    it('can only grab consigned addresses for sender', async () => {
+      await instance.consign(tokenId, accounts[8], commission, { from: tokenOwner });
+      await instance.consign(tokenId, accounts[7], commission, { from: accounts[8] });
+
+      const result = await instance.getConsignmentAddresses(tokenId, { from: tokenOwner });
+
+      expect(result[0]).be.eql(accounts[8]);
     });
   });
 

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -157,6 +157,22 @@ contract('Consignment', async accounts => {
     });
   });
 
+  describe('get consignment info', async () => {
+    beforeEach(async () => {
+      await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
+      const balance = await registry.balanceOf(tokenOwner);
+      tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
+    });
+
+    it('can grab single consigned info for a tokenId', async () => {
+      await instance.consign(tokenId, accounts[8], 15, { from: tokenOwner });
+
+      const result = await instance.getConsignmentInfo(tokenId, tokenOwner, accounts[8]);
+
+      expect(result.toNumber()).be.eql(15);
+    });
+  });
+
   describe('transfer', async () => {
     const buyer = accounts[7];
     const metaUri = 'metaUri';

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -173,7 +173,7 @@ contract('Consignment', async accounts => {
     });
 
     it('returns 0 for invalid params', async () => {
-      const result = await instance.getConsignmentInfo(99999, tokenOwner, accounts[8]);
+      const result = await instance.getConsignmentInfo(tokenId tokenOwner, accounts[8]);
 
       expect(result.toNumber()).be.eql(0);
     });

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -111,6 +111,23 @@ contract('Consignment', async accounts => {
     });
   });
 
+  describe('get consignment info', async () => {
+    beforeEach(async () => {
+      await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
+      const balance = await registry.balanceOf(tokenOwner);
+      tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
+    });
+
+    it('can grab consigned info for a tokenId', async () => {
+      await instance.consign(tokenId, accounts[8], commission, { from: tokenOwner });
+
+      const result = await instance.getConsignmentInfo(tokenId, { from: accounts[8] });
+
+      expect(result[0]).be.eql(accounts[0]);
+      expect(result[1].toNumber()).be.eql(commission);
+    });
+  });
+
   describe('transfer', async () => {
     const buyer = accounts[7];
     const metaUri = 'metaUri';

--- a/test/Consignment.js
+++ b/test/Consignment.js
@@ -1,0 +1,66 @@
+const { expectRevert } = require('@openzeppelin/test-helpers');
+const { ARTIFACT } = require('./constants/artifact');
+
+const Consignment = artifacts.require('Consignment');
+const ArtifactRegistry = artifacts.require('./ArtifactRegistry.sol');
+const Governance = artifacts.require('./Governance.sol');
+
+contract('Consignment', async accounts => {
+  const tokenOwner = accounts[0];
+  const commission = 30;
+
+  let instance;
+  let registry;
+  let tokenId;
+
+  before(async () => {
+    const governance = await Governance.deployed();
+    registry = await ArtifactRegistry.new(tokenOwner, governance.address, { from: tokenOwner });
+    instance = await Consignment.new(registry.address);
+
+    await registry.mint(tokenOwner, ARTIFACT, { from: tokenOwner });
+    const balance = await registry.balanceOf(tokenOwner);
+    tokenId = await registry.tokenOfOwnerByIndex(tokenOwner, balance - 1);
+
+    registry.approve(instance.address, tokenId);
+  });
+
+  describe('authorize', async () => {
+    it('token owner can consign', async () => {
+      await instance.consign(tokenId, accounts[1], commission, { from: tokenOwner });
+    });
+
+    it('consigned account can consign', async () => {
+      await instance.consign(tokenId, accounts[2], commission, { from: accounts[1] });
+    });
+
+    it('chained consigned account can consign', async () => {
+      await instance.consign(tokenId, accounts[3], commission, { from: accounts[2] });
+    });
+
+    it('non-consigned account cannot consign', async () => {
+      await expectRevert(
+        instance.consign(tokenId, accounts[4], commission, { from: accounts[5] }),
+        'Consignment::authorized: Account not authorized'
+      );
+    });
+  });
+
+  describe('transfer', async () => {
+    it('token owner can transfer', async () => {
+
+    });
+
+    it('authorized account can transfer', async () => {
+
+    });
+
+    it('chained authorized account can transfer', async () => {
+
+    });
+
+    it('non-authorized account cannot transfer', async () => {
+
+    });
+  });
+});


### PR DESCRIPTION
Some of the functionality this includes

- You can consign to multiple accounts
- Consigned accounts can consign accounts themselves
- You can see what accounts you have directly consigned too
- You can see all accounts you have indirectly consigned too
- You can provide a commission value along with a consignment
- You can revoke a consignment (That account and accounts that account have consigned will all get revoked)
- On transfer all accounts get consignment revoked
- Cannot consign to an account that is already consigned.

![consignment-multi](https://user-images.githubusercontent.com/21280865/69899379-15644300-135d-11ea-87db-3eafe05bfe0f.png)

