### PR TITLE
Hide original register sale dialog when transfer is taking place

### DIFF
--- a/app/src/components/TransferArtifact.tsx
+++ b/app/src/components/TransferArtifact.tsx
@@ -83,6 +83,7 @@ const TransferArtifact: React.FC<TransferArtifactProps> = ({ tokenId, metaUri })
   const transferArtwork = async (_: React.FormEvent): Promise<void> => {
     let owner = '';
     setSubmitted(true);
+    setShowTransferForm(false);
 
     const isHexAddress = fields.recipientName.includes('0x');
 
@@ -154,6 +155,7 @@ const TransferArtifact: React.FC<TransferArtifactProps> = ({ tokenId, metaUri })
 
     console.log('takesARR', takesArr);
     transferPromise.then((receipt: any) => {
+      setSubmitted(false);
       showRegisterSaleCompleteForm(takesArr, receipt, salePrice);
     }).catch(console.log);
   };


### PR DESCRIPTION
Hide the original register sale dialog when transfer is taking place (loading).

I kept the loading bar in as it seemed a bit weird without it.